### PR TITLE
feat/transferHenkakuWhenBuyTicket

### DIFF
--- a/test/helper/deploy.ts
+++ b/test/helper/deploy.ts
@@ -1,0 +1,29 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { BigNumber } from 'ethers'
+import { HenkakuToken, HenkakuToken__factory, Ticket__factory } from '../../typechain-types'
+import { ethers } from 'hardhat'
+
+export const deployTicket = async (henkakuTokenAddr: string) => {
+  const TicketFactory = (await ethers.getContractFactory('Ticket')) as Ticket__factory
+  const TicketContract = await TicketFactory.deploy('Henkaku Ticket', 'HNJ', henkakuTokenAddr)
+  await TicketContract.deployed()
+  return TicketContract
+}
+
+export const deployAndDistributeHenkakuV2: (params: {
+  deployer: SignerWithAddress
+  addresses: string[]
+  amount: BigNumber
+}) => Promise<HenkakuToken> = async ({ deployer, addresses, amount }) => {
+  const HenkakuV2Factory = (await ethers.getContractFactory('HenkakuToken')) as HenkakuToken__factory
+  const HenkakuV2Contract = await HenkakuV2Factory.connect(deployer).deploy()
+  await HenkakuV2Contract.deployed()
+
+  await HenkakuV2Contract.addWhitelistUsers(addresses)
+
+  for (const address of addresses) {
+    await HenkakuV2Contract.mint(address, amount)
+  }
+
+  return HenkakuV2Contract
+}


### PR DESCRIPTION
#10 #2 

やったこと
- TicketInfoにpoolWalletをセットできるように
- NFTのstruct (年賀状のときはNengajoInfo) にpriceとwalletを追加priceはチケットの価格、walletはチケット代が送金される先（お茶会では指定のgnosisにいくように設定する）
- mint関数にregister関数（年賀状のときはregisterNengajo）にあるHenkakuのtransfer処理を実装する
- register関数からHengakuのtransfer処理を消す
- calcPrice関数を消す

whenMintableのModifierがmint関数でしか使われておらず抽象化する必要ないとおもうので、mint関数内に入れちゃいましたが問題ないですかね？