### PR TITLE
Feature/revenue sharing

### DIFF
--- a/contracts/community/InteractHenkakuToken.sol
+++ b/contracts/community/InteractHenkakuToken.sol
@@ -13,21 +13,20 @@ abstract contract InteractHenakuToken is Administration, MintManager {
     }
 
     function transferHenkakuV2(uint256 _amount, address _to) internal {
-        require(checkHenkakuV2Balance(_amount), "Ticket: Insufficient HenkakuV2 token");
+        _checkHenkakuV2Balance(_amount);
         bool sent = IHenkakuToken(henkakuV2).transferFrom(msg.sender, _to, _amount);
         require(sent, "Ticket: Henkaku transfer failed");
     }
 
-    function batchTransferHenkakuV2(uint256[] memory _amounts, address[] memory _to) internal {
+    function batchTransferHenkakuV2(uint256 totalPrice, uint256[] memory _amounts, address[] memory _to) internal {
+        _checkHenkakuV2Balance(totalPrice);
+
         uint256[] memory amounts = _amounts;
         uint256 amountsLength = amounts.length;
         require(amountsLength == _to.length, "amounts and to length mismatch");
 
         for (uint256 i = 0; i < amountsLength; ) {
-            uint256 amount = amounts[i];
-
-            require(checkHenkakuV2Balance(amount), "Ticket: Insufficient HenkakuV2 token");
-            bool sent = IHenkakuToken(henkakuV2).transferFrom(msg.sender, _to[i], amount);
+            bool sent = IHenkakuToken(henkakuV2).transferFrom(msg.sender, _to[i], amounts[i]);
             require(sent, "Ticket: Henkaku transfer failed");
 
             unchecked {
@@ -36,7 +35,10 @@ abstract contract InteractHenakuToken is Administration, MintManager {
         }
     }
 
-    function checkHenkakuV2Balance(uint256 _requiredAmount) internal view returns (bool) {
-        return IHenkakuToken(henkakuV2).balanceOf(msg.sender) >= _requiredAmount ? true : false;
+    function _checkHenkakuV2Balance(uint256 _requiredAmount) internal view {
+        require(
+            IHenkakuToken(henkakuV2).balanceOf(msg.sender) >= _requiredAmount,
+            "Ticket: Insufficient HenkakuV2 token"
+        );
     }
 }

--- a/contracts/community/InteractHenkakuToken.sol
+++ b/contracts/community/InteractHenkakuToken.sol
@@ -18,6 +18,24 @@ abstract contract InteractHenakuToken is Administration, MintManager {
         require(sent, "Ticket: Henkaku transfer failed");
     }
 
+    function batchTransferHenkakuV2(uint256[] memory _amounts, address[] memory _to) internal {
+        uint256[] memory amounts = _amounts;
+        uint256 amountsLength = amounts.length;
+        require(amountsLength == _to.length, "amounts and to length mismatch");
+
+        for (uint256 i = 0; i < amountsLength; ) {
+            uint256 amount = amounts[i];
+
+            require(checkHenkakuV2Balance(amount), "Ticket: Insufficient HenkakuV2 token");
+            bool sent = IHenkakuToken(henkakuV2).transferFrom(msg.sender, _to[i], amount);
+            require(sent, "Ticket: Henkaku transfer failed");
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
     function checkHenkakuV2Balance(uint256 _requiredAmount) internal view returns (bool) {
         return IHenkakuToken(henkakuV2).balanceOf(msg.sender) >= _requiredAmount ? true : false;
     }

--- a/contracts/community/Ticket.sol
+++ b/contracts/community/Ticket.sol
@@ -41,7 +41,6 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
      */
     struct TicketInfo {
         address creator;
-        address poolWallet;
         uint64 open_blockTimestamp;
         uint64 close_blockTimestamp;
         uint64 maxSupply;
@@ -62,9 +61,7 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         name = _name;
         symbol = _symbol;
 
-        registeredTickets.push(
-            TicketInfo(address(0), address(0), 0, 0, 0, 0, 0, "", new uint256[](0), new address[](0))
-        );
+        registeredTickets.push(TicketInfo(address(0), 0, 0, 0, 0, 0, "", new uint256[](0), new address[](0)));
         _tokenIds.increment();
     }
 
@@ -92,13 +89,11 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         uint256 _price,
         uint64 _open_blockTimestamp,
         uint64 _close_blockTimestamp,
-        address _poolWallet,
         address[] memory _shareholdersAddresses,
         uint256[] memory _sharesAmounts
     ) external onlyHenkakuHolders {
         if (
             _maxSupply == 0 ||
-            _poolWallet == address(0) ||
             keccak256(bytes(_metaDataURL)) == keccak256(bytes("")) ||
             _getTotalSharesAmounts(_sharesAmounts) != _price
         ) revert InvalidParams("Ticket: invalid params");
@@ -108,7 +103,6 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         registeredTickets.push(
             TicketInfo(
                 msg.sender,
-                _poolWallet,
                 _open_blockTimestamp,
                 _close_blockTimestamp,
                 _maxSupply,

--- a/contracts/community/Ticket.sol
+++ b/contracts/community/Ticket.sol
@@ -62,7 +62,9 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         name = _name;
         symbol = _symbol;
 
-        registeredTickets.push(TicketInfo(address(0), address(0), 0, 0, 0, 0, 0, ""));
+        registeredTickets.push(
+            TicketInfo(address(0), address(0), 0, 0, 0, 0, 0, "", new uint256[](0), new address[](0))
+        );
         _tokenIds.increment();
     }
 
@@ -77,7 +79,9 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         uint256 _price,
         uint64 _open_blockTimestamp,
         uint64 _close_blockTimestamp,
-        address poolWallet
+        address poolWallet,
+        address[] memory _shareholdersAddresses,
+        uint256[] memory _sharesAmounts
     ) external onlyHenkakuHolders {
         if (_maxSupply == 0 || poolWallet == address(0) || keccak256(bytes(_metaDataURL)) == keccak256(bytes("")))
             revert InvalidParams("Ticket: invalid params");
@@ -93,7 +97,9 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
                 _maxSupply,
                 tokenId,
                 _price,
-                _metaDataURL
+                _metaDataURL,
+                _sharesAmounts,
+                _shareholdersAddresses
             )
         );
         _tokenIds.increment();
@@ -107,7 +113,9 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
             _maxSupply,
             tokenId,
             _price,
-            _metaDataURL
+            _metaDataURL,
+            _sharesAmounts,
+            _shareholdersAddresses
         );
     }
 

--- a/contracts/community/Ticket.sol
+++ b/contracts/community/Ticket.sol
@@ -160,7 +160,7 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
 
         ownerOfMintedIds[msg.sender].push(_tokenId);
 
-        transferHenkakuV2(ticket.price, ticket.poolWallet);
+        batchTransferHenkakuV2(ticket.sharesAmounts, ticket.shareholdersAddresses);
 
         _mint(msg.sender, _tokenId, 1, "");
 

--- a/contracts/community/Ticket.sol
+++ b/contracts/community/Ticket.sol
@@ -26,7 +26,9 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         uint64 maxSupply,
         uint256 tokenId,
         uint256 price,
-        string metaDataURL
+        string metaDataURL,
+        uint256[] sharesAmounts,
+        address[] shareholdersAddresses
     );
     event Mint(address indexed minter, uint256 indexed tokenId);
 
@@ -46,6 +48,8 @@ contract Ticket is ERC1155, ERC1155Supply, Administration, MintManager, Interact
         uint256 id;
         uint256 price;
         string uri;
+        uint256[] sharesAmounts;
+        address[] shareholdersAddresses;
     }
 
     TicketInfo[] private registeredTickets;

--- a/test/community_ticket.ts
+++ b/test/community_ticket.ts
@@ -53,10 +53,10 @@ describe('RegisterTicket', () => {
 
     // @dev test emit register creative
     await expect(
-      TicketContract.connect(creator).registerTicket(2, 'ipfs://test1', 100, now, now + 1000000000000, deployer.address)
+      TicketContract.connect(creator).registerTicket(2, 'ipfs://test1', 100, now, now + 1000000000000, deployer.address, [creator.address, deployer.address], [60, 40])
     )
       .to.emit(TicketContract, 'RegisterTicket')
-      .withArgs(creator.address, now, now + 1000000000000, 2, 1, 100, 'ipfs://test1')
+      .withArgs(creator.address, now, now + 1000000000000, 2, 1, 100, 'ipfs://test1', [60, 40], [creator.address, deployer.address])
 
     tokenURI = await TicketContract.uri(1)
     expect(tokenURI).equal('ipfs://test1')
@@ -81,7 +81,7 @@ describe('RegisterTicket', () => {
   it('revert register creative', async () => {
     // @dev test revert register creative
     expect(await HenkakuTokenContract.balanceOf(outsider.address)).to.equal(0)
-    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, deployer.address)).to.be.revertedWith('Ticket: Insufficient Henkaku Token Balance')
+    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, deployer.address, [outsider.address, deployer.address], [60, 40])).to.be.revertedWith('Ticket: Insufficient Henkaku Token Balance')
   })
 
 })
@@ -117,7 +117,9 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address
+      deployer.address,
+      [creator.address, deployer.address],
+      [60, 40]
     )
 
     await TicketContract.connect(creator).registerTicket(
@@ -126,7 +128,9 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address
+      deployer.address,
+      [creator.address, deployer.address],
+      [60, 40]
     )
 
     await TicketContract.connect(creator).registerTicket(
@@ -135,10 +139,12 @@ describe('MintTicket', () => {
       100,
       now + 1000000000000,
       now + 1000000000000,
-      deployer.address
+      deployer.address,
+      [creator.address, deployer.address],
+      [60, 40]
     )
 
-    await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, deployer.address)
+    await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, deployer.address, [creator.address, deployer.address], [60, 40])
 
     await TicketContract.connect(creator).registerTicket(
       1,
@@ -146,7 +152,9 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address
+      deployer.address,
+      [creator.address, deployer.address],
+      [60, 40]
     )
   })
 
@@ -361,7 +369,9 @@ describe('check henkaku token transfer', () => {
       ethers.utils.parseEther('100'),
       now,
       now + 1000000000000,
-      deployer.address
+      deployer.address,
+      [creator.address, deployer.address],
+      [ethers.utils.parseEther('60'), ethers.utils.parseEther('40')]
     )
 
     await TicketContract.connect(deployer).switchMintable()

--- a/test/community_ticket.ts
+++ b/test/community_ticket.ts
@@ -53,7 +53,7 @@ describe('RegisterTicket', () => {
 
     // @dev test emit register creative
     await expect(
-      TicketContract.connect(creator).registerTicket(2, 'ipfs://test1', 100, now, now + 1000000000000, deployer.address, [creator.address, deployer.address], [60, 40])
+      TicketContract.connect(creator).registerTicket(2, 'ipfs://test1', 100, now, now + 1000000000000, [creator.address, deployer.address], [60, 40])
     )
       .to.emit(TicketContract, 'RegisterTicket')
       .withArgs(creator.address, now, now + 1000000000000, 2, 1, 100, 'ipfs://test1', [60, 40], [creator.address, deployer.address])
@@ -81,7 +81,7 @@ describe('RegisterTicket', () => {
   it('revert register creative', async () => {
     // @dev test revert register creative
     expect(await HenkakuTokenContract.balanceOf(outsider.address)).to.equal(0)
-    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, deployer.address, [outsider.address, deployer.address], [60, 40])).to.be.revertedWith('Ticket: Insufficient HenkakuV2 token')
+    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, [outsider.address, deployer.address], [60, 40])).to.be.revertedWith('Ticket: Insufficient HenkakuV2 token')
   })
 
 })
@@ -117,7 +117,6 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address,
       [creator.address, deployer.address],
       [60, 40]
     )).not.to.be.reverted
@@ -128,7 +127,6 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address,
       [creator.address, deployer.address],
       [60, 40]
     )).not.to.be.reverted
@@ -139,12 +137,11 @@ describe('MintTicket', () => {
       100,
       now + 1000000000000,
       now + 1000000000000,
-      deployer.address,
       [creator.address, deployer.address],
       [60, 40]
     )).not.to.be.reverted
 
-    expect(await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, deployer.address, [creator.address, deployer.address], [60, 40])).not.to.be.reverted
+    expect(await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, [creator.address, deployer.address], [60, 40])).not.to.be.reverted
 
     expect(await TicketContract.connect(creator).registerTicket(
       1,
@@ -152,7 +149,6 @@ describe('MintTicket', () => {
       100,
       now,
       now + 1000000000000,
-      deployer.address,
       [creator.address, deployer.address],
       [60, 40]
     )).not.to.be.reverted
@@ -369,7 +365,6 @@ describe('check henkaku token transfer', () => {
       ethers.utils.parseEther('100'),
       now,
       now + 1000000000000,
-      deployer.address,
       [creator.address, deployer.address],
       [ethers.utils.parseEther('60'), ethers.utils.parseEther('40')]
     )).not.to.be.reverted

--- a/test/community_ticket.ts
+++ b/test/community_ticket.ts
@@ -111,7 +111,7 @@ describe('MintTicket', () => {
 
     let now = (await ethers.provider.getBlock('latest')).timestamp
 
-    await TicketContract.connect(creator).registerTicket(
+    expect(await TicketContract.connect(creator).registerTicket(
       2,
       'ipfs://test1',
       100,
@@ -120,9 +120,9 @@ describe('MintTicket', () => {
       deployer.address,
       [creator.address, deployer.address],
       [60, 40]
-    )
+    )).not.to.be.reverted
 
-    await TicketContract.connect(creator).registerTicket(
+    expect(await TicketContract.connect(creator).registerTicket(
       2,
       'ipfs://test1',
       100,
@@ -131,9 +131,9 @@ describe('MintTicket', () => {
       deployer.address,
       [creator.address, deployer.address],
       [60, 40]
-    )
+    )).not.to.be.reverted
 
-    await TicketContract.connect(creator).registerTicket(
+    expect(await TicketContract.connect(creator).registerTicket(
       1,
       'ipfs://test1',
       100,
@@ -142,11 +142,11 @@ describe('MintTicket', () => {
       deployer.address,
       [creator.address, deployer.address],
       [60, 40]
-    )
+    )).not.to.be.reverted
 
-    await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, deployer.address, [creator.address, deployer.address], [60, 40])
+    expect(await TicketContract.connect(creator).registerTicket(1, 'ipfs://test1', 100, now, 0, deployer.address, [creator.address, deployer.address], [60, 40])).not.to.be.reverted
 
-    await TicketContract.connect(creator).registerTicket(
+    expect(await TicketContract.connect(creator).registerTicket(
       1,
       'ipfs://test1',
       100,
@@ -155,7 +155,7 @@ describe('MintTicket', () => {
       deployer.address,
       [creator.address, deployer.address],
       [60, 40]
-    )
+    )).not.to.be.reverted
   })
 
   it('mint ticket', async () => {
@@ -363,7 +363,7 @@ describe('check henkaku token transfer', () => {
     await HenkakuTokenContract.connect(user2).approve(TicketContract.address, ethers.utils.parseEther('1000'))
 
     let now = (await ethers.provider.getBlock('latest')).timestamp
-    await TicketContract.connect(creator).registerTicket(
+    expect(await TicketContract.connect(creator).registerTicket(
       1,
       'ipfs://test1',
       ethers.utils.parseEther('100'),
@@ -372,25 +372,29 @@ describe('check henkaku token transfer', () => {
       deployer.address,
       [creator.address, deployer.address],
       [ethers.utils.parseEther('60'), ethers.utils.parseEther('40')]
-    )
+    )).not.to.be.reverted
 
     await TicketContract.connect(deployer).switchMintable()
   })
 
   it('success to transfer ticket', async () => {
     expect(await HenkakuTokenContract.balanceOf(user1.address)).to.be.equal(ethers.utils.parseEther('1000'))
+    expect(await HenkakuTokenContract.balanceOf(creator.address)).to.be.equal(ethers.utils.parseEther('1000'))
+    expect(await HenkakuTokenContract.balanceOf(deployer.address)).to.be.equal(ethers.utils.parseEther('1000'))
 
     const tx = await TicketContract.connect(user1).mint(1)
     await tx.wait()
 
     expect(await HenkakuTokenContract.balanceOf(user1.address)).to.be.equal(ethers.utils.parseEther('900'))
-    expect(await HenkakuTokenContract.balanceOf(deployer.address)).to.be.equal(ethers.utils.parseEther('1100'))
+    expect(await HenkakuTokenContract.balanceOf(creator.address)).to.be.equal(ethers.utils.parseEther('1060'))
+    expect(await HenkakuTokenContract.balanceOf(deployer.address)).to.be.equal(ethers.utils.parseEther('1040'))
   })
 
   it('fail to mint and henkaku token is not transfered', async () => {
     await expect(TicketContract.connect(user2).mint(1)).revertedWith('Ticket: Mint limit reached')
     expect(await HenkakuTokenContract.balanceOf(user2.address)).to.be.equal(ethers.utils.parseEther('1000'))
-    expect(await HenkakuTokenContract.balanceOf(deployer.address)).to.be.equal(ethers.utils.parseEther('1100'))
+    expect(await HenkakuTokenContract.balanceOf(creator.address)).to.be.equal(ethers.utils.parseEther('1060'))
+    expect(await HenkakuTokenContract.balanceOf(deployer.address)).to.be.equal(ethers.utils.parseEther('1040'))
   })
 })
 

--- a/test/community_ticket.ts
+++ b/test/community_ticket.ts
@@ -81,7 +81,7 @@ describe('RegisterTicket', () => {
   it('revert register creative', async () => {
     // @dev test revert register creative
     expect(await HenkakuTokenContract.balanceOf(outsider.address)).to.equal(0)
-    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, deployer.address, [outsider.address, deployer.address], [60, 40])).to.be.revertedWith('Ticket: Insufficient Henkaku Token Balance')
+    await expect(TicketContract.connect(outsider).registerTicket(2, 'ipfs://test1', 100, 0, 0, deployer.address, [outsider.address, deployer.address], [60, 40])).to.be.revertedWith('Ticket: Insufficient HenkakuV2 token')
   })
 
 })
@@ -220,13 +220,13 @@ describe('MintTicket', () => {
   })
 
   it('failed with insufficient Henkaku Token', async () => {
-    await expect(TicketContract.connect(user4).mint(5)).to.be.revertedWith('Ticket: Insufficient Henkaku Token Balance')
+    await expect(TicketContract.connect(user4).mint(5)).to.be.revertedWith('Ticket: Insufficient HenkakuV2 token')
   })
 
   it('revert register creative', async () => {
     // @dev test revert register creative
     expect(await HenkakuTokenContract.balanceOf(outsider.address)).to.equal(0)
-    await expect(TicketContract.connect(outsider).mint(5)).to.be.revertedWith('Ticket: Insufficient Henkaku Token Balance')
+    await expect(TicketContract.connect(outsider).mint(5)).to.be.revertedWith('Ticket: Insufficient HenkakuV2 token')
   })
 })
 


### PR DESCRIPTION
#20 レベニューシェアの実装です！

やったこと
- TicketInfoストラクトに、関係者たちのウォレットの配列と関係者たちに支払う金額の配列を追加
- RegisterTicketイベントに、上記２つを追加
- `registerTicket()` の引数に上記2つを追加して、`TicketInfo[] private registeredTickets` に保存
- `mint()` が実行された時、関係者たちのウォレットにそれぞれに支払う金額がトランスファーされるコードを追加
- ERC20周りの重複したコードを軽量化